### PR TITLE
[REQ-5] @Async 메서드에서 메인워커쓰레드의 ThreadLocal를 전파받아, 별도의 ThreadLocal를 생성한다

### DIFF
--- a/src/main/java/com/kenny/poc/atp/config/AsyncConfiguration.java
+++ b/src/main/java/com/kenny/poc/atp/config/AsyncConfiguration.java
@@ -22,6 +22,8 @@ public class AsyncConfiguration implements AsyncConfigurer {
         executor.setMaxPoolSize(100);
         executor.setQueueCapacity(10000);
         executor.setThreadNamePrefix("async-thread-");
+        // ThreadLocal 전파를 위한 데코레이터 클래스 설정
+        executor.setTaskDecorator(new ContextPropagationDecorator());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/kenny/poc/atp/config/ContextPropagationDecorator.java
+++ b/src/main/java/com/kenny/poc/atp/config/ContextPropagationDecorator.java
@@ -1,0 +1,29 @@
+package com.kenny.poc.atp.config;
+
+import com.kenny.poc.atp.context.Context;
+import com.kenny.poc.atp.context.ContextHolder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.task.TaskDecorator;
+
+@Slf4j
+public class ContextPropagationDecorator implements TaskDecorator {
+    @Override
+    public Runnable decorate(final Runnable runnable) {
+        final Context threadLocalContext = ContextHolder.getThreadLocalContext();
+        log.warn("# decorate threadLocalContext : {}", threadLocalContext);
+        return () -> {
+                try {
+                    // 비동기 쓰레드를 시작하기전에 ThreadLocal값을 전파(복사) 한다
+                    ContextHolder.setThreadLocalContext(threadLocalContext);
+                    log.warn("# decorate runnable threadLocalContext : {}", ContextHolder.getThreadLocalContext());
+
+                    // 비동기 쓰레드 시작
+                    runnable.run();
+
+                } finally {
+                    // 비동기 쓰레드 종료 후 자원정리
+                    ContextHolder.resetContexts();
+                }
+        };
+    }
+}

--- a/src/main/java/com/kenny/poc/atp/context/ContextHolder.java
+++ b/src/main/java/com/kenny/poc/atp/context/ContextHolder.java
@@ -19,10 +19,24 @@ public class ContextHolder {
     }
 
     /*
-     * Context를 ThreadLocal에 set한다
+     * Context를 ThreadLocal, InheritableThreadLocalContext에 set한다
      */
     public static void setContext( final Context context ) {
         threadLocalContext.set(context);
+        inheritableThreadLocalContext.set(context);
+    }
+
+    /*
+     * Context를 ThreadLocal에 set한다
+     */
+    public static void setThreadLocalContext( final Context context ) {
+        threadLocalContext.set(context);
+    }
+
+    /*
+     * Context를 ThreadLocal에 set한다
+     */
+    public static void setInheritableThreadLocalContext( final Context context ) {
         inheritableThreadLocalContext.set(context);
     }
 

--- a/src/main/java/com/kenny/poc/atp/controller/AsyncController.java
+++ b/src/main/java/com/kenny/poc/atp/controller/AsyncController.java
@@ -17,7 +17,7 @@ public class AsyncController {
     private final AsyncService asyncService;
 
     @GetMapping("/async/threadlocal/{userId}/{guid}")
-    public void getAsyncThreadLocal( @PathVariable final String userId, @PathVariable final String guid ) {
+    public void getAsyncThreadLocal( @PathVariable final String userId, @PathVariable final String guid ) throws InterruptedException {
         log.warn("# Controller getAsyncThreadLocal() Start!!");
 
         try {
@@ -30,6 +30,10 @@ public class AsyncController {
 
             ContextHolder.printLog();
             asyncService.asyncProcess();
+
+            // @Async로 실행되는 asyncProcess()가 끝나고, 메인 쓰레드의 쓰레드로컬값은 그대로 유지되는지 확인하기 위해 슬립처리함
+            Thread.sleep(2000L);
+            ContextHolder.printLog();
 
         } catch( Exception e ) {
             throw e;


### PR DESCRIPTION
1. ThreadPoolTaskExecutor에 ThreadLocal을 복사하기 위한 데코레이터 추가
2. 비동기처리 후에도 메인워커쓰레드의 쓰레드로컬이 유지되는지 확인되기 위해 Sleep으로 확인
3. ContextHolder의 쓰레드로컬별로 context를 설정할 수 있는 메서드 추가
4. 1번에서 사용하기 위한 데코레이터 추가

issue: REQ-5