### PR TITLE
[REQ-6] kafka consumer에서 context를 받아 threadlocal에 set하는 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/kenny/poc/atp/AsyncThreadlocalPropagationPocApplication.java
+++ b/src/main/java/com/kenny/poc/atp/AsyncThreadlocalPropagationPocApplication.java
@@ -2,6 +2,7 @@ package com.kenny.poc.atp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @SpringBootApplication
 public class AsyncThreadlocalPropagationPocApplication {

--- a/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumer.java
+++ b/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumer.java
@@ -1,7 +1,7 @@
 package com.kenny.poc.atp.consumer;
 
-import com.kenny.poc.atp.event.CommonMessage;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class KafkaConsumer {
 
     @KafkaListener(topics = {"defaultTopic"}, groupId = "common-message-group")
-    public void subscribe(final CommonMessage commonMessage ) {
-        log.warn("# sub : {}", commonMessage);
+    public void subscribe(final ConsumerRecord<?, ?> record) {
+        log.warn("# sub : {}", record);
     }
 }

--- a/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumerAspect.java
+++ b/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumerAspect.java
@@ -1,0 +1,47 @@
+package com.kenny.poc.atp.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kenny.poc.atp.context.Context;
+import com.kenny.poc.atp.context.ContextHolder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aopalliance.intercept.Joinpoint;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaConsumerAspect {
+
+    private final ObjectMapper objectMapper;
+
+    @Before("@annotation(org.springframework.kafka.annotation.KafkaListener)")
+    public void beforeKafkaConsumer(Joinpoint jp, ConsumerRecord<?, ?> record) throws JsonProcessingException {
+        final String contextString = new String(record.headers().lastHeader("context").value());
+        log.warn("# beforeKafkaConsumer : {}", contextString);
+
+        final Context context = objectMapper.readValue(contextString, Context.class);
+
+        ContextHolder.setContext(context);
+        ContextHolder.printLog();
+    }
+
+    @After("@annotation(org.springframework.kafka.annotation.KafkaListener)")
+    public void afterKafkaConsumer() {
+        log.warn("# afterKafkaConsumer : 자원을 정리한다" );
+        ContextHolder.resetContexts();
+    }
+
+    @AfterThrowing("@annotation(org.springframework.kafka.annotation.KafkaListener)")
+    public void afterThrowingKafkaConsumer() {
+        log.warn("# afterThrowingKafkaConsumer : 자원을 정리한다" );
+        ContextHolder.resetContexts();
+    }
+}

--- a/src/main/java/com/kenny/poc/atp/controller/AsyncController.java
+++ b/src/main/java/com/kenny/poc/atp/controller/AsyncController.java
@@ -1,5 +1,6 @@
 package com.kenny.poc.atp.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kenny.poc.atp.context.Context;
 import com.kenny.poc.atp.context.ContextHolder;
 import com.kenny.poc.atp.service.AsyncService;
@@ -17,7 +18,7 @@ public class AsyncController {
     private final AsyncService asyncService;
 
     @GetMapping("/async/threadlocal/{userId}/{guid}")
-    public void getAsyncThreadLocal( @PathVariable final String userId, @PathVariable final String guid ) throws InterruptedException {
+    public void getAsyncThreadLocal( @PathVariable final String userId, @PathVariable final String guid ) throws InterruptedException, JsonProcessingException {
         log.warn("# Controller getAsyncThreadLocal() Start!!");
 
         try {

--- a/src/main/java/com/kenny/poc/atp/event/CommonMessage.java
+++ b/src/main/java/com/kenny/poc/atp/event/CommonMessage.java
@@ -1,13 +1,15 @@
 package com.kenny.poc.atp.event;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Getter
-@Builder
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommonMessage {
 
-    private final LocalDateTime curruentDateTime;
+    private String yyyymmdd;
 }

--- a/src/main/java/com/kenny/poc/atp/producer/KafkaProducer.java
+++ b/src/main/java/com/kenny/poc/atp/producer/KafkaProducer.java
@@ -1,8 +1,14 @@
 package com.kenny.poc.atp.producer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kenny.poc.atp.context.Context;
+import com.kenny.poc.atp.context.ContextHolder;
 import com.kenny.poc.atp.event.CommonMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -11,10 +17,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class KafkaProducer {
 
-    private final KafkaTemplate<String, CommonMessage> kafkaTemplate;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
 
-    public void sendMessage( final String topic, final CommonMessage payload ) {
+    public void sendMessage( final String topic, final CommonMessage payload ) throws JsonProcessingException {
+        // context 가져오기
+        final Context inheritableThreadLocalContext = ContextHolder.getInheritableThreadLocalContext();
+
+        // kafka에 전달할 record 생성 & context를 header에 넣기
+        final ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topic, objectMapper.writeValueAsString(payload));
+        producerRecord.headers().add(new RecordHeader("context", objectMapper.writeValueAsString(inheritableThreadLocalContext).getBytes()));
+
+        // kafka에 비동기로 send
         // TODO: 비동기처리 결과에 대한 로직 추가되어야 함
-        kafkaTemplate.send(topic, payload);
+        kafkaTemplate.send(producerRecord);
     }
 }

--- a/src/main/java/com/kenny/poc/atp/service/AsyncService.java
+++ b/src/main/java/com/kenny/poc/atp/service/AsyncService.java
@@ -1,20 +1,28 @@
 package com.kenny.poc.atp.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kenny.poc.atp.context.ContextHolder;
+import com.kenny.poc.atp.event.CommonMessage;
+import com.kenny.poc.atp.producer.KafkaProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AsyncService {
 
-    @Async
-    public void asyncProcess() {
-        log.warn("# asyncProcess Start!!!");
+    private final KafkaProducer kafkaProducer;
 
+    @Async
+    public void asyncProcess() throws JsonProcessingException {
+        log.warn("# asyncProcess Start!!!");
         ContextHolder.printLog();
+
+        kafkaProducer.sendMessage("defaultTopic", new CommonMessage("20231127"));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,14 @@
 spring:
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: localhost:29092
     # Producer 설정
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
     # Consumer 설정
     consumer:
-      bootstrap-servers: localhost:9092
+      bootstrap-servers: localhost:29092
       group-id: common-message-group
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION
1. kafka bootstrap-server 포트를 29092로 변경
2. AsyncService에서 kafka message send 로직 추가
3. @KafkaListener에서 AOP로 threadlocal을 셋팅할 수 있도록 aop 의존성 추가
4. CommonMessage를 String 타입으로 변경 : deserialization 문제가 있어서, 이 이슈 해결하기 전까지는 일단 String으로 테스트
5. KafkaConsumerAspect 클래스 추가 : 단! 현재 @Before에서 서버기동시 익셉션이 발생하고 있고, 디버깅 해야함!
6. KafkaProducer에서 kafka로 send시 header에 context 로직 담도록 추가

issue: REQ-6