### PR TITLE
Feature/req 6

### DIFF
--- a/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumer.java
+++ b/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumer.java
@@ -9,6 +9,10 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class KafkaConsumer {
 
+    // TODO : payload를 String이 아니라 Object로 받도록 수정
+    // TODO : consumer group으로 consumer를 엮어서 어떻게 동작하는지 확인
+    // TODO : consumer 처리 오류시 몇번까지 retry 하는지, 그 이후에는 어떻게 되는지 확인
+    // TODO : kafka의 현재 offset이 어떻게 되는지 확인하는 방법
     @KafkaListener(topics = {"defaultTopic"}, groupId = "common-message-group")
     public void subscribe(final ConsumerRecord<String, String> record) {
         log.warn("# sub : {}", record);

--- a/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumer.java
+++ b/src/main/java/com/kenny/poc/atp/consumer/KafkaConsumer.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class KafkaConsumer {
 
     @KafkaListener(topics = {"defaultTopic"}, groupId = "common-message-group")
-    public void subscribe(final ConsumerRecord<?, ?> record) {
+    public void subscribe(final ConsumerRecord<String, String> record) {
         log.warn("# sub : {}", record);
     }
 }

--- a/src/main/java/com/kenny/poc/atp/context/ContextHolder.java
+++ b/src/main/java/com/kenny/poc/atp/context/ContextHolder.java
@@ -57,8 +57,8 @@ public class ContextHolder {
     /*
      * ThreadLocal에 담겨있는 Context 객체를 출력한다
      */
-    public static void printLog() {
-        log.warn("# threadLocalContext : {}", threadLocalContext.get().toString());
-        log.warn("# inheritableThreadLocalContext : {}", inheritableThreadLocalContext.get().toString());
+    public static void printLog( final String methodName ) {
+        log.warn("# [{}] threadLocalContext : {}", methodName, threadLocalContext.get().toString());
+        log.warn("# [{}] inheritableThreadLocalContext : {}", methodName, inheritableThreadLocalContext.get().toString());
     }
 }

--- a/src/main/java/com/kenny/poc/atp/controller/AsyncController.java
+++ b/src/main/java/com/kenny/poc/atp/controller/AsyncController.java
@@ -29,12 +29,12 @@ public class AsyncController {
                     .build()
             );
 
-            ContextHolder.printLog();
+            ContextHolder.printLog("getAsyncThreadLocal");
             asyncService.asyncProcess();
 
             // @Async로 실행되는 asyncProcess()가 끝나고, 메인 쓰레드의 쓰레드로컬값은 그대로 유지되는지 확인하기 위해 슬립처리함
             Thread.sleep(2000L);
-            ContextHolder.printLog();
+            ContextHolder.printLog("getAsyncThreadLocal");
 
         } catch( Exception e ) {
             throw e;

--- a/src/main/java/com/kenny/poc/atp/service/AsyncService.java
+++ b/src/main/java/com/kenny/poc/atp/service/AsyncService.java
@@ -21,7 +21,7 @@ public class AsyncService {
     @Async
     public void asyncProcess() throws JsonProcessingException {
         log.warn("# asyncProcess Start!!!");
-        ContextHolder.printLog();
+        ContextHolder.printLog("asyncProcess");
 
         kafkaProducer.sendMessage("defaultTopic", new CommonMessage("20231127"));
     }


### PR DESCRIPTION
- 원인
    - https://github.com/before에 args를 기술하지 않았음
    - AOP가 적용되는 메서드의 시그니처와 args를 일치시켜야함

issue: REQ-6